### PR TITLE
Fixes path separator when passing the include paths to native code

### DIFF
--- a/src/main/java/io/bit3/jsass/adapter/NativeAdapter.java
+++ b/src/main/java/io/bit3/jsass/adapter/NativeAdapter.java
@@ -125,7 +125,7 @@ public class NativeAdapter {
     String includePath = includePathsList
         .stream()
         .map(File::getAbsolutePath)
-        .collect(Collectors.joining(File.separator));
+        .collect(Collectors.joining(File.pathSeparator));
 
     String indent = options.getIndent();
 


### PR DESCRIPTION
When including more than one include path, they are joined using a file separator (/) rather than a path separator (:). Originally, when one includes the following two paths:
- `/some/path/A`
- `/some/path/B`

the following path would be passed to the native code:

`/some/path/A//some/path/B`

while it should have been:

`/some/path/A:/some/path/B`