### PR TITLE
Throw Exceptions on compile errors

### DIFF
--- a/src/main/java/io/bit3/jsass/CompilationException.java
+++ b/src/main/java/io/bit3/jsass/CompilationException.java
@@ -2,14 +2,56 @@ package io.bit3.jsass;
 
 public class CompilationException extends Exception {
 
-  private int status;
+  private Output output;
 
-  public CompilationException(int status, String message) {
-    super(message);
-    this.status = status;
+  public CompilationException(Output output) {
+    super(output.getErrorText());
+    this.output = output;
   }
 
-  public int getStatus() {
-    return status;
+  public Output getOutput() {
+    return output;
+  }
+
+  /**
+   * @see Output#getErrorStatus()
+   */
+  public int getErrorStatus() {
+    return getOutput().getErrorStatus();
+  }
+
+  /**
+   * @see Output#getErrorJson()
+   */
+  public String getErrorJson() {
+    return getOutput().getErrorJson();
+  }
+
+  /**
+   * @see Output#getErrorText()
+   */
+  public String getErrorText() {
+    return getOutput().getErrorText();
+  }
+
+  /**
+   * @see Output#getErrorMessage()
+   */
+  public String getErrorMessage() {
+    return getOutput().getErrorMessage();
+  }
+
+  /**
+   * @see Output#getErrorFile()
+   */
+  public String getErrorFile() {
+    return getOutput().getErrorFile();
+  }
+
+  /**
+   * @see Output#getErrorSrc()
+   */
+  public String getErrorSrc() {
+    return getOutput().getErrorSrc();
   }
 }

--- a/src/main/java/io/bit3/jsass/CompilationException.java
+++ b/src/main/java/io/bit3/jsass/CompilationException.java
@@ -9,48 +9,33 @@ public class CompilationException extends Exception {
     this.output = output;
   }
 
+  /**
+   * @return The {@link Output} of the failed compilation.
+   */
   public Output getOutput() {
     return output;
   }
 
-  /**
-   * @see Output#getErrorStatus()
-   */
   public int getErrorStatus() {
     return getOutput().getErrorStatus();
   }
 
-  /**
-   * @see Output#getErrorJson()
-   */
   public String getErrorJson() {
     return getOutput().getErrorJson();
   }
 
-  /**
-   * @see Output#getErrorText()
-   */
   public String getErrorText() {
     return getOutput().getErrorText();
   }
 
-  /**
-   * @see Output#getErrorMessage()
-   */
   public String getErrorMessage() {
     return getOutput().getErrorMessage();
   }
 
-  /**
-   * @see Output#getErrorFile()
-   */
   public String getErrorFile() {
     return getOutput().getErrorFile();
   }
 
-  /**
-   * @see Output#getErrorSrc()
-   */
   public String getErrorSrc() {
     return getOutput().getErrorSrc();
   }

--- a/src/main/java/io/bit3/jsass/adapter/NativeAdapter.java
+++ b/src/main/java/io/bit3/jsass/adapter/NativeAdapter.java
@@ -55,6 +55,12 @@ public class NativeAdapter {
     return checkForError(compileString(nativeContext));
   }
 
+  /**
+   * Checks if the given {@link Output} contains an error.
+   *
+   * @return The given {@link Output}
+   * @throws CompilationException If an error was found in the given {@link Output}
+   */
   private Output checkForError(Output output) throws CompilationException {
     if (output.getErrorStatus() != 0) {
       throw new CompilationException(output);

--- a/src/main/java/io/bit3/jsass/adapter/NativeAdapter.java
+++ b/src/main/java/io/bit3/jsass/adapter/NativeAdapter.java
@@ -1,5 +1,6 @@
 package io.bit3.jsass.adapter;
 
+import io.bit3.jsass.CompilationException;
 import io.bit3.jsass.Options;
 import io.bit3.jsass.Output;
 import io.bit3.jsass.context.Context;
@@ -38,9 +39,9 @@ public class NativeAdapter {
    *
    * @return The compiled result.
    */
-  public Output compile(FileContext context, ImportStack importStack) {
+  public Output compile(FileContext context, ImportStack importStack) throws CompilationException {
     NativeFileContext nativeContext = convertToNativeContext(context, importStack);
-    return compileFile(nativeContext);
+    return checkForError(compileFile(nativeContext));
   }
 
   /**
@@ -48,9 +49,16 @@ public class NativeAdapter {
    *
    * @return The compiled result.
    */
-  public Output compile(StringContext context, ImportStack importStack) {
+  public Output compile(StringContext context, ImportStack importStack) throws CompilationException {
     NativeStringContext nativeContext = convertToNativeContext(context, importStack);
-    return compileString(nativeContext);
+    return checkForError(compileString(nativeContext));
+  }
+
+  private Output checkForError(Output output) throws CompilationException {
+    if(output.getErrorStatus() != 0) {
+      throw new CompilationException(output);
+    }
+    return output;
   }
 
   private NativeFileContext convertToNativeContext(

--- a/src/main/java/io/bit3/jsass/adapter/NativeAdapter.java
+++ b/src/main/java/io/bit3/jsass/adapter/NativeAdapter.java
@@ -49,13 +49,14 @@ public class NativeAdapter {
    *
    * @return The compiled result.
    */
-  public Output compile(StringContext context, ImportStack importStack) throws CompilationException {
+  public Output compile(StringContext context, ImportStack importStack)
+          throws CompilationException {
     NativeStringContext nativeContext = convertToNativeContext(context, importStack);
     return checkForError(compileString(nativeContext));
   }
 
   private Output checkForError(Output output) throws CompilationException {
-    if(output.getErrorStatus() != 0) {
+    if (output.getErrorStatus() != 0) {
       throw new CompilationException(output);
     }
     return output;


### PR DESCRIPTION
Throwing an Exception is more java like than hiding the error information in an output object