### PR TITLE
Add slf4j simple dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
-    runtime group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.21'
+    testCompile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.21'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
+    runtime group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.21'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 


### PR DESCRIPTION
I was getting [this](http://www.slf4j.org/codes.html#StaticLoggerBinder) error: Failed to load class org.slf4j.impl.StaticLoggerBinder. And no logs were showing up running `./gradlew test --debug`. So I added the simple logger and now the logs show up. Presumably this worked for others without this dependency, but I'm not sure how.